### PR TITLE
Snack show

### DIFF
--- a/app/controllers/snacks_controller.rb
+++ b/app/controllers/snacks_controller.rb
@@ -1,0 +1,5 @@
+class SnacksController < ApplicationController
+  def show
+    @snack = Snack.find(params[:id])
+  end
+end

--- a/app/models/snack.rb
+++ b/app/models/snack.rb
@@ -2,4 +2,10 @@ class Snack < ApplicationRecord
   validates_presence_of :name, :price
   belongs_to :machine
 
+
+  def locations
+    snack_id = self.id
+    Machine.joins(:snacks).where('snacks.id = ?', snack_id)
+    binding.pry
+  end
 end

--- a/app/views/snacks/show.html.erb
+++ b/app/views/snacks/show.html.erb
@@ -1,0 +1,2 @@
+<h1><%= @snack.name %></h1>
+<h3><%= number_to_currency(@snack.price) %></h3>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,4 +6,6 @@ Rails.application.routes.draw do
   end
 
   resources :machines, only: [:show]
+
+  resources :snacks, only: [:show]
 end

--- a/db/migrate/20191025164459_create_machine_snacks.rb
+++ b/db/migrate/20191025164459_create_machine_snacks.rb
@@ -1,0 +1,8 @@
+class CreateMachineSnacks < ActiveRecord::Migration[5.1]
+  def change
+    create_table :machine_snacks do |t|
+      t.references :snack, foreign_key: true
+      t.references :machine, foreign_key: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,17 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191025154813) do
+ActiveRecord::Schema.define(version: 20191025164459) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "machine_snacks", force: :cascade do |t|
+    t.bigint "snack_id"
+    t.bigint "machine_id"
+    t.index ["machine_id"], name: "index_machine_snacks_on_machine_id"
+    t.index ["snack_id"], name: "index_machine_snacks_on_snack_id"
+  end
 
   create_table "machines", force: :cascade do |t|
     t.string "location"
@@ -42,6 +49,8 @@ ActiveRecord::Schema.define(version: 20191025154813) do
     t.datetime "updated_at", null: false
   end
 
+  add_foreign_key "machine_snacks", "machines"
+  add_foreign_key "machine_snacks", "snacks"
   add_foreign_key "machines", "owners"
   add_foreign_key "snacks", "machines"
 end

--- a/spec/features/snacks/show_spec.rb
+++ b/spec/features/snacks/show_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+describe 'On the Snack Show Page' do
+  describe 'As a visitor' do
+    it 'I see lots of information about that snack' do
+      sam = Owner.create(name: "Sam's Snacks")
+      machine = sam.machines.create(location: "Turing Basement")
+      machine2 = sam.machines.create(location: "Train Station")
+      snack1 = machine.snacks.create(name: 'Twix', price: 1.50)
+      snack1 = machine2.snacks.create(name: 'Twix', price: 1.50)
+      snack2 = machine.snacks.create(name: 'Chips', price: 2.0)
+      snack3 = machine2.snacks.create(name: 'Doughnuts', price: 2.5)
+
+
+      visit snack_path(snack1)
+      expect(page).to have_content(snack1.name)
+      expect(page).to have_content("$#{snack1.price.round(2)}")
+
+      expect(page).to have_content("Locations")
+    end
+  end
+end
+
+# As a visitor
+# When I visit a snack show page
+# I see the name of that snack
+#   and I see the price for that snack
+#   and I see a list of locations with vending machines that carry that snack
+#   and I see the average price for snacks in those vending machines
+#   and I see a count of the different kinds of items in that vending machine.

--- a/spec/models/machine_spec.rb
+++ b/spec/models/machine_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe Machine, type: :model do
   end
 
   describe 'relationships' do
-    it {should have_many :snacks}
+    it {should have_many :machine_snacks}
+    it {should have_many :snacks, through: :machine_snacks}
   end
 
   describe 'methods' do

--- a/spec/models/snack_spec.rb
+++ b/spec/models/snack_spec.rb
@@ -10,4 +10,20 @@ describe Snack, type: :model do
   describe "relationships" do
     it {should belong_to :machine}
   end
+
+  describe 'methods' do
+    it 'returns a list of all machine locations for a snack' do
+      sam = Owner.create(name: "Sam's Snacks")
+      machine = sam.machines.create(location: "Turing Basement")
+      machine2 = sam.machines.create(location: "Train Station")
+      machine3 = sam.machines.create(location: "Campus Rec Room")
+
+      snack1 = machine.snacks.create(name: 'Twix', price: 1.50)
+      snack1 = machine2.snacks.create(name: 'Twix', price: 1.50)
+
+      snack3 = machine3.snacks.create(name: 'Dont show', price: 500.0)
+
+      expect(snack1.locations).to eq(['Turing Basement', 'Train station'])
+    end
+  end
 end


### PR DESCRIPTION
For User Story 3: Showing a bunch of Snack-Machine information
Realized I needed a many-to-many relationship between snacks and machines.
Next Step is to refactor feature and model specs to take this into account. Then complete the many-to-many relationship with the machine_snacks joins table resource. Then redo feature stories to match with 'dream-driving' methods.