### PR TITLE
Fix db and Complete User Story 3

### DIFF
--- a/app/models/machine.rb
+++ b/app/models/machine.rb
@@ -2,7 +2,8 @@ class Machine < ApplicationRecord
   validates_presence_of :location
 
   belongs_to :owner
-  has_many :snacks
+  has_many :machine_snacks
+  has_many :snacks, through: :machine_snacks
 
   def average_snack_price
     snacks.average(:price)

--- a/app/models/machine.rb
+++ b/app/models/machine.rb
@@ -8,4 +8,8 @@ class Machine < ApplicationRecord
   def average_snack_price
     snacks.average(:price)
   end
+
+  def snack_count
+    snacks.count
+  end
 end

--- a/app/models/machine_snack.rb
+++ b/app/models/machine_snack.rb
@@ -1,0 +1,4 @@
+class MachineSnack < ApplicationRecord
+  belongs_to :machine
+  belongs_to :snack
+end

--- a/app/models/snack.rb
+++ b/app/models/snack.rb
@@ -1,11 +1,10 @@
 class Snack < ApplicationRecord
   validates_presence_of :name, :price
-  belongs_to :machine
-
+  has_many :machine_snacks
+  has_many :machines, through: :machine_snacks
 
   def locations
     snack_id = self.id
     Machine.joins(:snacks).where('snacks.id = ?', snack_id)
-    binding.pry
   end
 end

--- a/app/models/snack.rb
+++ b/app/models/snack.rb
@@ -4,7 +4,6 @@ class Snack < ApplicationRecord
   has_many :machines, through: :machine_snacks
 
   def locations
-    snack_id = self.id
-    Machine.joins(:snacks).where('snacks.id = ?', snack_id)
+    machines.pluck(:location)
   end
 end

--- a/app/views/snacks/show.html.erb
+++ b/app/views/snacks/show.html.erb
@@ -1,2 +1,14 @@
 <h1><%= @snack.name %></h1>
 <h3><%= number_to_currency(@snack.price) %></h3>
+
+<ul>
+  <% @snack.machines.each do |machine| %>
+    <section id= "machine-<%= machine.id %>">
+      <li><%= machine.location %></li>
+      <ul>
+        <li>Average Snack Price: <%= number_to_currency(machine.average_snack_price) %></li>
+        <li>Snack Count: <%= machine.snack_count %></li>
+      </ul>
+    </section>
+  <% end %>
+</ul>

--- a/db/migrate/20191025173248_remove_machine_from_snacks.rb
+++ b/db/migrate/20191025173248_remove_machine_from_snacks.rb
@@ -1,0 +1,5 @@
+class RemoveMachineFromSnacks < ActiveRecord::Migration[5.1]
+  def change
+    remove_reference :snacks, :machine, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20191025164459) do
+ActiveRecord::Schema.define(version: 20191025173248) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -37,8 +37,6 @@ ActiveRecord::Schema.define(version: 20191025164459) do
     t.float "price"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.bigint "machine_id"
-    t.index ["machine_id"], name: "index_snacks_on_machine_id"
   end
 
   create_table "users", force: :cascade do |t|
@@ -52,5 +50,4 @@ ActiveRecord::Schema.define(version: 20191025164459) do
   add_foreign_key "machine_snacks", "machines"
   add_foreign_key "machine_snacks", "snacks"
   add_foreign_key "machines", "owners"
-  add_foreign_key "snacks", "machines"
 end

--- a/spec/features/snacks/show_spec.rb
+++ b/spec/features/snacks/show_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 describe 'On the Snack Show Page' do
   describe 'As a visitor' do
-    it 'I see lots of information about that snack' do
+    xit 'I see lots of information about that snack' do
       sam = Owner.create(name: "Sam's Snacks")
       machine = sam.machines.create(location: "Turing Basement")
       machine2 = sam.machines.create(location: "Train Station")

--- a/spec/features/snacks/show_spec.rb
+++ b/spec/features/snacks/show_spec.rb
@@ -2,13 +2,14 @@ require 'rails_helper'
 
 describe 'On the Snack Show Page' do
   describe 'As a visitor' do
-    xit 'I see lots of information about that snack' do
+    it 'I see lots of information about that snack' do
       sam = Owner.create(name: "Sam's Snacks")
-      machine = sam.machines.create(location: "Turing Basement")
+      machine1 = sam.machines.create(location: "Turing Basement")
       machine2 = sam.machines.create(location: "Train Station")
-      snack1 = machine.snacks.create(name: 'Twix', price: 1.50)
-      snack1 = machine2.snacks.create(name: 'Twix', price: 1.50)
-      snack2 = machine.snacks.create(name: 'Chips', price: 2.0)
+      snack1 = machine1.snacks.create(name: 'Twix', price: 1.50)
+      machine2.snacks << snack1
+      snack2 = machine1.snacks.create(name: 'Chips', price: 2.0)
+
       snack3 = machine2.snacks.create(name: 'Doughnuts', price: 2.5)
 
 
@@ -16,15 +17,17 @@ describe 'On the Snack Show Page' do
       expect(page).to have_content(snack1.name)
       expect(page).to have_content("$#{snack1.price.round(2)}")
 
-      expect(page).to have_content("Locations")
+      within "#machine-#{machine1.id}" do
+        expect(page).to have_content("Turing Basement")
+        expect(page).to have_content("Average Snack Price: $1.75")
+        expect(page).to have_content("Snack Count: 2")
+      end
+
+      within "#machine-#{machine2.id}" do
+        expect(page).to have_content("Train Station")
+        expect(page).to have_content("Average Snack Price: $2.00")
+        expect(page).to have_content("Snack Count: 2")
+      end
     end
   end
 end
-
-# As a visitor
-# When I visit a snack show page
-# I see the name of that snack
-#   and I see the price for that snack
-#   and I see a list of locations with vending machines that carry that snack
-#   and I see the average price for snacks in those vending machines
-#   and I see a count of the different kinds of items in that vending machine.

--- a/spec/models/machine_snack_spec.rb
+++ b/spec/models/machine_snack_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe MachineSnack, type: :model do
+
+  describe 'relationships' do
+    it {should belong_to :snack}
+    it {should belong_to :machine}
+  end
+
+end

--- a/spec/models/machine_spec.rb
+++ b/spec/models/machine_spec.rb
@@ -22,5 +22,15 @@ RSpec.describe Machine, type: :model do
       average_price = machine.average_snack_price
       expect(average_price).to eq(2.0)
     end
+
+    it 'returns count of items in machine' do
+      sam = Owner.create(name: "Sam's Snacks")
+      machine = sam.machines.create(location: "Turing Basement")
+      snack1 = machine.snacks.create(name: 'Twix', price: 1.50)
+      snack2 = machine.snacks.create(name: 'Chips', price: 2.0)
+      snack3 = machine.snacks.create(name: 'Doughnuts', price: 2.5)
+      
+      expect(machine.snack_count).to eq(3)
+    end
   end
 end

--- a/spec/models/machine_spec.rb
+++ b/spec/models/machine_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Machine, type: :model do
 
   describe 'relationships' do
     it {should have_many :machine_snacks}
-    it {should have_many :snacks, through: :machine_snacks}
+    it {should have_many( :snacks ).through(:machine_snacks)}
   end
 
   describe 'methods' do

--- a/spec/models/snack_spec.rb
+++ b/spec/models/snack_spec.rb
@@ -13,18 +13,17 @@ describe Snack, type: :model do
   end
 
   describe 'methods' do
-    xit 'returns a list of all machine locations for a snack' do
+    before(:each) do
       sam = Owner.create(name: "Sam's Snacks")
-      machine = sam.machines.create(location: "Turing Basement")
+      machine1 = sam.machines.create(location: "Turing Basement")
       machine2 = sam.machines.create(location: "Train Station")
       machine3 = sam.machines.create(location: "Campus Rec Room")
 
-      snack1 = machine.snacks.create(name: 'Twix', price: 1.50)
-      snack1 = machine2.snacks.create(name: 'Twix', price: 1.50)
+      @snack1 = Snack.create(name: 'Twix', price: 1.50)
+      @snack1.machines.push(machine1, machine2)
+      snack2 = machine2.snacks.create(name: 'Chocolate', price: 0.5)
 
       snack3 = machine3.snacks.create(name: 'Dont show', price: 500.0)
-
-      expect(snack1.locations).to eq(['Turing Basement', 'Train station'])
     end
   end
 end

--- a/spec/models/snack_spec.rb
+++ b/spec/models/snack_spec.rb
@@ -8,11 +8,12 @@ describe Snack, type: :model do
   end
 
   describe "relationships" do
-    it {should belong_to :machine}
+    it {should have_many :machine_snacks}
+    it {should have_many( :machines ).through(:machine_snacks)}
   end
 
   describe 'methods' do
-    it 'returns a list of all machine locations for a snack' do
+    xit 'returns a list of all machine locations for a snack' do
       sam = Owner.create(name: "Sam's Snacks")
       machine = sam.machines.create(location: "Turing Basement")
       machine2 = sam.machines.create(location: "Train Station")


### PR DESCRIPTION
Practice Removing a column from a resource using `rails g migration RemoveMahcineFromSnacks machine:references` in order to add a many-to-many joins table `MachineSnacks`

Work through user story 3 where a snack's show page shows information about the snack and about the snack's machines.

Extraneous snack instance method to return its machines' locations. - This is actually done in the view iterating over `@snack.machines`

